### PR TITLE
fix: :bug: added optional chaining in title and placeholder image

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -91,9 +91,18 @@ function App() {
                   key={e.id}
                 >
                   <Box>
-                    <b>Name:</b> {tokenDataObjects[i].title}&nbsp;
+                    <b>Name:</b>{' '}
+                    {tokenDataObjects[i].title?.length === 0
+                      ? 'No Name'
+                      : tokenDataObjects[i].title}
                   </Box>
-                  <Image src={tokenDataObjects[i].rawMetadata.image} />
+                  <Image
+                    src={
+                      tokenDataObjects[i]?.rawMetadata?.image ??
+                      'https://via.placeholder.com/200'
+                    }
+                    alt={'Image'}
+                  />
                 </Flex>
               );
             })}


### PR DESCRIPTION
added a feature to make sure that the app doesn't crash when showing the NFT of an account without name or images.
title has ternary operator to make sure that if the title is empty string, then display 'No Name" and if images is empty then display a placeholder image. 